### PR TITLE
Add support for Umbraco 11

### DIFF
--- a/PersonalisationGroups.Core/ServicesConfiguration.cs
+++ b/PersonalisationGroups.Core/ServicesConfiguration.cs
@@ -66,7 +66,7 @@ namespace Our.Umbraco.PersonalisationGroups.Core
 
             services.AddUnique<IHostProvider, HttpContextHostProvider>();
             services.AddUnique<IIpProvider, HttpContextIpProvider>();
-            services.AddUnique<ClientIpParser>();
+            services.AddSingleton<ClientIpParser>();
             services.AddUnique<IMemberGroupProvider, UmbracoMemberGroupProvider>();
             services.AddUnique<IMemberProfileFieldProvider, UmbracoMemberProfileFieldProvider>();
             services.AddUnique<IMemberTypeProvider, UmbracoMemberTypeProvider>();


### PR DESCRIPTION
The below error appears when trying to use this package with Umbraco 11:
![image](https://user-images.githubusercontent.com/200450/209158727-a6b00bc7-6202-415d-9609-85a5d777dd51.png)

```
System.MissingMethodException: Method not found: 'Void Umbraco.Extensions.ServiceCollectionExtensions.AddUnique(Microsoft.Extensions.DependencyInjection.IServiceCollection)'.
   at Our.Umbraco.PersonalisationGroups.Core.ServicesConfiguration.AddProviders(IServiceCollection services, IConfigurationSection configSection)
   at Our.Umbraco.PersonalisationGroups.Core.ServicesConfiguration.AddPersonalisationGroups(IUmbracoBuilder builder, IConfiguration config)
```

`AddUnique` requires both a `TService` and `TImplementing` in Umbraco 11, so I believe switching this to `AddSingleton` should resolve the issue?