### PR TITLE
Fixed cookie and session criteria such that checking for "does not match regex" with a missing cookie or session key returns true.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,5 +201,6 @@ TestWebApp.V9/
 TestWebApp.V10/
 TestWebApp.V11/
 TestWebApp.V12/
+TestWebApp.V13/
 
 deploy.ps1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Version>3.2.9</Version>
-		<AssemblyVersion>3.2.9</AssemblyVersion>
-		<InformationalVersion>3.2.9</InformationalVersion>
-		<FileVersion>3.2.9</FileVersion>
+		<Version>3.2.10</Version>
+		<AssemblyVersion>3.2.10</AssemblyVersion>
+		<InformationalVersion>3.2.10</InformationalVersion>
+		<FileVersion>3.2.10</FileVersion>
 		<LangVersion Condition="'$(LangVersion)' == ''">10.0</LangVersion>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<TargetFramework>net5.0</TargetFramework>

--- a/PersonalisationGroups.Core/Criteria/Cookie/CookiePersonalisationGroupCriteria.cs
+++ b/PersonalisationGroups.Core/Criteria/Cookie/CookiePersonalisationGroupCriteria.cs
@@ -70,7 +70,7 @@ namespace Our.Umbraco.PersonalisationGroups.Core.Criteria.Cookie
                 case CookieSettingMatch.MatchesRegex:
                     return cookieExists && MatchesRegex(cookieValue, cookieSetting.Value);
                 case CookieSettingMatch.DoesNotMatchRegex:
-                    return cookieExists && !MatchesRegex(cookieValue, cookieSetting.Value);
+                    return !cookieExists || !MatchesRegex(cookieValue, cookieSetting.Value);
                 default:
                     return false;
             }

--- a/PersonalisationGroups.Core/Criteria/Session/SessionPersonalisationGroupCriteria.cs
+++ b/PersonalisationGroups.Core/Criteria/Session/SessionPersonalisationGroupCriteria.cs
@@ -70,7 +70,7 @@ namespace Our.Umbraco.PersonalisationGroups.Core.Criteria.Session
                 case SessionSettingMatch.MatchesRegex:
                     return keyExists && MatchesRegex(value, sessionSetting.Value);
                 case SessionSettingMatch.DoesNotMatchRegex:
-                    return keyExists && !MatchesRegex(value, sessionSetting.Value);
+                    return !keyExists || !MatchesRegex(value, sessionSetting.Value);
 
                 default:
                     return false;

--- a/PersonalisationGroups.Tests/Criteria/Cookie/CookiePersonalisationGroupCriteriaTests.cs
+++ b/PersonalisationGroups.Tests/Criteria/Cookie/CookiePersonalisationGroupCriteriaTests.cs
@@ -366,6 +366,21 @@ namespace Our.Umbraco.PersonalisationGroups.Tests.Criteria.Cookie
         }
 
         [Test]
+        public void CookiePersonalisationGroupCriteria_MatchesVisitor_WithDefinitionDoesNotMatchRegex_WithMissingCookie_ReturnsTrue()
+        {
+            // Arrange
+            var mockCookieProvider = MockCookieProvider();
+            var criteria = new CookiePersonalisationGroupCriteria(mockCookieProvider.Object);
+            var definition = string.Format(DefinitionFormat, "missing-key", "DoesNotMatchRegex", "[a-z]");
+
+            // Act
+            var result = criteria.MatchesVisitor(definition);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
         public void CookiePersonalisationGroupCriteria_MatchesVisitor_WithDefinitionDoesNotMatchRegex_WithMatchingCookie_ReturnsFalse()
         {
             // Arrange

--- a/PersonalisationGroups.Tests/Criteria/Session/SessionPersonalisationGroupCriteriaTests.cs
+++ b/PersonalisationGroups.Tests/Criteria/Session/SessionPersonalisationGroupCriteriaTests.cs
@@ -365,6 +365,21 @@ namespace Our.Umbraco.PersonalisationGroups.Tests.Criteria.Session
         }
 
         [Test]
+        public void SessionPersonalisationGroupCriteria_MatchesVisitor_WithDefinitionDoesNotMatchRegex_WithMissingSession_ReturnsTrue()
+        {
+            // Arrange
+            var mockSessionProvider = MockSessionProvider();
+            var criteria = new SessionPersonalisationGroupCriteria(mockSessionProvider.Object);
+            var definition = string.Format(DefinitionFormat, "missing-key", "DoesNotMatchRegex", "[a-z]");
+
+            // Act
+            var result = criteria.MatchesVisitor(definition);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
         public void SessionPersonalisationGroupCriteria_MatchesVisitor_WithDefinitionDoesNotMatchRegex_WithMatchingSession_ReturnsFalse()
         {
             // Arrange

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -399,3 +399,5 @@ See [here](https://github.com/AndyButland/UmbracoPersonalisationGroups#version-h
     - Added configuration option `DisableUserActivityTracking` to resolve issue [#10](https://github.com/AndyButland/UmbracoPersonalisationGroupsCore/issues/10)
 - 3.2.9
     - Extended version range to support Umbraco 13.
+- 3.2.10
+    - Fixed cookie and session criteria such that checking for "does not match regex" with a missing cookie or session key returns true.


### PR DESCRIPTION
As raised in comment here: https://github.com/AndyButland/UmbracoPersonalisationGroupsCore/issues/15#issuecomment-1986051452